### PR TITLE
Use rsplit instead of rstrip to get old_wp_names

### DIFF
--- a/wp.py
+++ b/wp.py
@@ -128,7 +128,7 @@ def make_work_packages(data_dir, wp_config):
             if filename == "master.gpkg":
                 continue  # skip the master file - it's not a work package
             if filename.endswith(".gpkg"):
-                wp_name = filename.rstrip(".gpkg")
+                wp_name = filename.rsplit(".gpkg")[0]
                 old_wp_names.append(wp_name)
     print("existing WPs: " + str(old_wp_names))
 

--- a/wp_mergin.py
+++ b/wp_mergin.py
@@ -101,7 +101,7 @@ master_wp_dir = os.path.join(master_dir, "work-packages")
 if os.path.exists(master_wp_dir):
     for f in os.listdir(master_wp_dir):
         if f.endswith(".gpkg") and f != "master.gpkg" and f not in wp_names:
-            missing_wp_name = f.rstrip(".gpkg")
+            missing_wp_name = f.rsplit(".gpkg")[0]
             print(f"Removing '{missing_wp_name}' work package as it's not used anymore.")
             os.remove(os.path.join(master_wp_dir, f))
 


### PR DESCRIPTION
Resolves #20 