### PR TITLE
Change wp_mergin to a proper module with functions + fixes

### DIFF
--- a/wp_mergin.py
+++ b/wp_mergin.py
@@ -28,46 +28,76 @@ import shutil
 import tempfile
 import argparse
 from wp_utils import download_project_with_cache
-from wp import load_config_from_yaml, make_work_packages
+from wp import load_config_from_yaml, make_work_packages, WPConfig
 
-parser = argparse.ArgumentParser()
-parser.add_argument("mergin_project", nargs="?")
-parser.add_argument("--cache-dir", nargs="?")
-parser.add_argument("--dry-run", action="store_true")
-params = parser.parse_args()
-master_mergin_project = params.mergin_project  # e.g.  martin/wp-master
-cache_dir = params.cache_dir
-dry_run = params.dry_run
 
-if not master_mergin_project:
-    raise ValueError("Need a parameter with master Mergin project name")
+class MerginWPContext:
+    """ Keeps the context of the current run of the tool """
+    def __init__(self):
+        self.dry_run = None
+        self.mc = None
 
-mergin_user = os.getenv("MERGIN_USERNAME")
-if mergin_user is None:
-    mergin_user = input("Mergin username: ")
+        self.master_mergin_project = None
 
-mergin_password = os.getenv("MERGIN_PASSWORD")
-if mergin_password is None:
-    mergin_password = getpass.getpass(f"Password for {mergin_user}: ")
+        self.tmp_dir = None
+        self.cache_dir = None
+        self.master_dir = None
+        self.master_config_yaml = None
+        self.wp_alg_dir = None
+        self.wp_alg_base_dir = None
+        self.wp_alg_input_dir = None
+        self.wp_alg_output_dir = None
 
-mergin_url = os.getenv("MERGIN_URL")
-if mergin_url is None:
-    mergin_url = mergin.MerginClient.default_url()
 
-# this will create a directory with a random name, e.g. /tmp/mergin-work-packages-w7tbsyd7
-tmp_dir = tempfile.mkdtemp(prefix="mergin-work-packages-")
+def parse_args() -> MerginWPContext:
+    """ Create context object from parsed command line arguments """
+    ctx = MerginWPContext()
 
-mc = mergin.MerginClient(url=mergin_url, login=mergin_user, password=mergin_password)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mergin_project", nargs="?")
+    parser.add_argument("--cache-dir", nargs="?")
+    parser.add_argument("--dry-run", action="store_true")
+    params = parser.parse_args()
+    ctx.master_mergin_project = params.mergin_project  # e.g.  martin/wp-master
+    ctx.cache_dir = params.cache_dir
+    ctx.dry_run = params.dry_run
 
-wp_alg_dir = os.path.join(tmp_dir, "wp")  # where we expect "base", "input" subdirs
-wp_alg_base_dir = os.path.join(wp_alg_dir, "base")
-wp_alg_input_dir = os.path.join(wp_alg_dir, "input")
-wp_alg_output_dir = os.path.join(wp_alg_dir, "output")
-os.makedirs(wp_alg_base_dir)
-os.makedirs(wp_alg_input_dir)
+    return ctx
 
-master_dir = os.path.join(tmp_dir, "master")
-master_config_yaml = os.path.join(master_dir, "mergin-work-packages.yml")
+
+def initialize(ctx: MerginWPContext):
+    """ Parse command line attributes + env vars and prepare context object """
+
+    if not ctx.master_mergin_project:
+        raise ValueError("Need a parameter with master Mergin project name")
+
+    mergin_user = os.getenv("MERGIN_USERNAME")
+    if mergin_user is None:
+        mergin_user = input("Mergin username: ")
+
+    mergin_password = os.getenv("MERGIN_PASSWORD")
+    if mergin_password is None:
+        mergin_password = getpass.getpass(f"Password for {mergin_user}: ")
+
+    mergin_url = os.getenv("MERGIN_URL")
+    if mergin_url is None:
+        mergin_url = mergin.MerginClient.default_url()
+
+    # this will create a directory with a random name, e.g. /tmp/mergin-work-packages-w7tbsyd7
+    ctx.tmp_dir = tempfile.mkdtemp(prefix="mergin-work-packages-")
+
+    ctx.mc = mergin.MerginClient(url=mergin_url, login=mergin_user, password=mergin_password)
+
+    ctx.wp_alg_dir = os.path.join(ctx.tmp_dir, "wp")  # where we expect "base", "input" subdirs
+    ctx.wp_alg_base_dir = os.path.join(ctx.wp_alg_dir, "base")
+    ctx.wp_alg_input_dir = os.path.join(ctx.wp_alg_dir, "input")
+    ctx.wp_alg_output_dir = os.path.join(ctx.wp_alg_dir, "output")
+    os.makedirs(ctx.wp_alg_base_dir)
+    os.makedirs(ctx.wp_alg_input_dir)
+
+    ctx.master_dir = os.path.join(ctx.tmp_dir, "master")
+    ctx.master_config_yaml = os.path.join(ctx.master_dir, "mergin-work-packages.yml")
+    return ctx
 
 
 def get_master_project_files(directory):
@@ -81,81 +111,78 @@ def get_master_project_files(directory):
             continue
         if not os.path.isfile(filename):
             continue
-        filename_relative = filename[len(directory) + 1 :]  # remove prefix
+        filename_relative = filename[len(directory) + 1:]  # remove prefix
         if len(filename_relative):
             files.append(filename_relative)
     return files
 
 
-#
-# 1. prepare directory with inputs
-#    - fetch master mergin project, read configuration in config.db, copy base files and master input file
-#    - fetch WP projects and copy their input files
-#
+def prepare_inputs(ctx: MerginWPContext) -> (WPConfig, set, str, list):
+    """
+    Prepare directory with inputs:
+    - fetch master mergin project, read configuration in config.db, copy base files and master input file
+    - fetch WP projects and copy their input files
+    """
 
+    if ctx.cache_dir is None:
+        print("No cache directory set: work packaging may be slow, it is recommended to use cache directory")
 
-print("Downloading master project " + master_mergin_project + "...")
-download_project_with_cache(mc, master_mergin_project, master_dir, cache_dir)
-print("Done.")
+    print("Downloading master project " + ctx.master_mergin_project + "...")
+    download_project_with_cache(ctx.mc, ctx.master_mergin_project, ctx.master_dir, ctx.cache_dir)
+    print("Done.")
 
-print("Reading configuration from " + master_config_yaml)
-wp_config = load_config_from_yaml(master_config_yaml)
+    print("Reading configuration from " + ctx.master_config_yaml)
+    wp_config = load_config_from_yaml(ctx.master_config_yaml)
 
-# Handling removed work packages
-wp_names = {f"{wp.name}.gpkg" for wp in wp_config.wp_names}
-master_wp_dir = os.path.join(master_dir, "work-packages")
-if os.path.exists(master_wp_dir):
-    for f in os.listdir(master_wp_dir):
-        if f.endswith(".gpkg") and f != "master.gpkg" and f not in wp_names:
-            missing_wp_name = f[:-5]  # strip the suffix
-            print(f"Removing '{missing_wp_name}' work package as it's not used anymore.")
-            os.remove(os.path.join(master_wp_dir, f))
+    # Handling removed work packages
+    wp_names = {f"{wp.name}.gpkg" for wp in wp_config.wp_names}
+    master_wp_dir = os.path.join(ctx.master_dir, "work-packages")
+    if os.path.exists(master_wp_dir):
+        for f in os.listdir(master_wp_dir):
+            if f.endswith(".gpkg") and f != "master.gpkg" and f not in wp_names:
+                missing_wp_name = f[:-5]  # strip the suffix
+                print(f"Removing '{missing_wp_name}' work package as it's not used anymore.")
+                os.remove(os.path.join(master_wp_dir, f))
 
-gpkg_path = wp_config.master_gpkg
+    gpkg_path = wp_config.master_gpkg
 
-shutil.copy(os.path.join(master_dir, gpkg_path), os.path.join(wp_alg_input_dir, "master.gpkg"))
+    shutil.copy(os.path.join(ctx.master_dir, gpkg_path), os.path.join(ctx.wp_alg_input_dir, "master.gpkg"))
 
-# the master.gpkg and remap.db should exist if this is not the first run of the tool
-if os.path.exists(os.path.join(master_dir, "work-packages", "master.gpkg")):
-    shutil.copy(os.path.join(master_dir, "work-packages", "master.gpkg"), os.path.join(wp_alg_base_dir, "master.gpkg"))
-if os.path.exists(os.path.join(master_dir, "work-packages", "remap.db")):
-    shutil.copy(os.path.join(master_dir, "work-packages", "remap.db"), os.path.join(wp_alg_base_dir, "remap.db"))
+    # the master.gpkg and remap.db should exist if this is not the first run of the tool
+    if os.path.exists(os.path.join(ctx.master_dir, "work-packages", "master.gpkg")):
+        shutil.copy(os.path.join(ctx.master_dir, "work-packages", "master.gpkg"),
+                    os.path.join(ctx.wp_alg_base_dir, "master.gpkg"))
+    if os.path.exists(os.path.join(ctx.master_dir, "work-packages", "remap.db")):
+        shutil.copy(os.path.join(ctx.master_dir, "work-packages", "remap.db"),
+                    os.path.join(ctx.wp_alg_base_dir, "remap.db"))
 
-master_project_files = get_master_project_files(master_dir)
-assert gpkg_path in master_project_files
-master_project_files.remove(gpkg_path)
-print("Master project files to copy to new projects: " + str(master_project_files))
+    master_project_files = get_master_project_files(ctx.master_dir)
+    assert gpkg_path in master_project_files
+    master_project_files.remove(gpkg_path)
+    print("Master project files to copy to new projects: " + str(master_project_files))
 
-# list of WP names that did not exist previously (and we will have to create a new Mergin project for them)
-wp_new = set()
+    # list of WP names that did not exist previously (and we will have to create a new Mergin project for them)
+    wp_new = set()
 
-for wp in wp_config.wp_names:
-    wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
-    wp_dir = os.path.join(tmp_dir, "wp-" + wp_name)
+    for wp in wp_config.wp_names:
+        wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
+        wp_dir = os.path.join(ctx.tmp_dir, "wp-" + wp_name)
 
-    wp_base_file = os.path.join(master_dir, "work-packages", wp_name + ".gpkg")
-    if os.path.exists(wp_base_file):  # already processed?
-        print("Preparing work package " + wp_name)
-        shutil.copy(wp_base_file, os.path.join(wp_alg_base_dir, wp_name + ".gpkg"))
+        wp_base_file = os.path.join(ctx.master_dir, "work-packages", wp_name + ".gpkg")
+        if os.path.exists(wp_base_file):  # already processed?
+            print("Preparing work package " + wp_name)
+            shutil.copy(wp_base_file, os.path.join(ctx.wp_alg_base_dir, wp_name + ".gpkg"))
 
-        print("Downloading work package project " + wp_mergin + "...")
-        download_project_with_cache(mc, wp_mergin, wp_dir, cache_dir)
-        print("Done.")
+            print("Downloading work package project " + wp_mergin + "...")
+            download_project_with_cache(ctx.mc, wp_mergin, wp_dir, ctx.cache_dir)
+            print("Done.")
 
-        shutil.copy(os.path.join(wp_dir, gpkg_path), os.path.join(wp_alg_input_dir, wp_name + ".gpkg"))
-    else:
-        print("First time encountered WP " + wp_name + " - not collecting input")
-        wp_new.add(wp_name)
+            shutil.copy(os.path.join(wp_dir, gpkg_path), os.path.join(ctx.wp_alg_input_dir, wp_name + ".gpkg"))
+        else:
+            print("First time encountered WP " + wp_name + " - not collecting input")
+            wp_new.add(wp_name)
 
-#
-# 2. run alg
-#
-
-make_work_packages(wp_alg_dir, wp_config)
-
-#
-# 3. push data to all projects
-#
+    return wp_config, wp_new, gpkg_path, master_project_files
 
 
 def push_mergin_project(mc, directory):
@@ -167,62 +194,86 @@ def push_mergin_project(mc, directory):
     return True
 
 
-for wp in wp_config.wp_names:
-    wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
-    wp_dir = os.path.join(tmp_dir, "wp-" + wp_name)
-    if wp_name in wp_new:
-        # we need to create new project
-        if not dry_run:
-            print("Creating project: " + wp_mergin + " for work package " + wp_name)
-            wp_mergin_project_namespace, wp_mergin_project_name = wp_mergin.split("/")
-            mc.create_project(wp_mergin_project_name, False, wp_mergin_project_namespace)
-            download_project_with_cache(mc, wp_mergin, wp_dir, cache_dir)
+def push_data_to_projects(ctx: MerginWPContext, wp_config, wp_new, gpkg_path, master_project_files):
+    """ Push data to all Mergin projects """
+
+    for wp in wp_config.wp_names:
+        wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
+        wp_dir = os.path.join(ctx.tmp_dir, "wp-" + wp_name)
+        if wp_name in wp_new:
+            # we need to create new project
+            if not ctx.dry_run:
+                print("Creating project: " + wp_mergin + " for work package " + wp_name)
+                wp_mergin_project_namespace, wp_mergin_project_name = wp_mergin.split("/")
+                ctx.mc.create_project(wp_mergin_project_name, False, wp_mergin_project_namespace)
+                download_project_with_cache(ctx.mc, wp_mergin, wp_dir, ctx.cache_dir)
+            else:
+                os.makedirs(wp_dir, exist_ok=True)  # Make WP project folder that would be created by the Mergin Client
+            shutil.copy(os.path.join(ctx.wp_alg_output_dir, wp_name + ".gpkg"), os.path.join(wp_dir, gpkg_path))
+
+            # copy other files from master project
+            for relative_filepath in master_project_files:
+                print("Adding file from master project: " + relative_filepath)
+                src_path = os.path.join(ctx.master_dir, relative_filepath)
+                dst_path = os.path.join(wp_dir, relative_filepath)
+                os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+                shutil.copy(src_path, dst_path)
+
+        # new version of the geopackage
+        shutil.copy(os.path.join(ctx.wp_alg_output_dir, wp_name + ".gpkg"), os.path.join(wp_dir, gpkg_path))
+
+        if ctx.dry_run:
+            print(f"This is a dry run - no changes pushed for work package: {wp_name}")
+            continue
+        print("Uploading new version of the project: " + wp_mergin + " for work package " + wp_name)
+        if push_mergin_project(ctx.mc, wp_dir):
+            print("Uploaded a new version: " + mergin.MerginProject(wp_dir).metadata["version"])
         else:
-            os.makedirs(wp_dir, exist_ok=True)  # Make WP project folder that would be created by the Mergin Client
-        shutil.copy(os.path.join(wp_alg_output_dir, wp_name + ".gpkg"), os.path.join(wp_dir, gpkg_path))
+            print("No changes (not creating a new version).")
 
-        # copy other files from master project
-        for relative_filepath in master_project_files:
-            print("Adding file from master project: " + relative_filepath)
-            src_path = os.path.join(master_dir, relative_filepath)
-            dst_path = os.path.join(wp_dir, relative_filepath)
-            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-            shutil.copy(src_path, dst_path)
+    # in the last step, let's update the master project
+    # (update the master database file and update base files for work packages)
+    shutil.copy(os.path.join(ctx.wp_alg_output_dir, "master.gpkg"), os.path.join(ctx.master_dir, gpkg_path))
+    if not os.path.exists(os.path.join(ctx.master_dir, "work-packages")):
+        os.makedirs(os.path.join(ctx.master_dir, "work-packages"))
+    shutil.copy(os.path.join(ctx.wp_alg_output_dir, "master.gpkg"),
+                os.path.join(ctx.master_dir, "work-packages", "master.gpkg"))
+    shutil.copy(os.path.join(ctx.wp_alg_output_dir, "remap.db"),
+                os.path.join(ctx.master_dir, "work-packages", "remap.db"))
+    for wp in wp_config.wp_names:
+        wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
+        shutil.copy(
+            os.path.join(ctx.wp_alg_output_dir, wp_name + ".gpkg"),
+            os.path.join(ctx.master_dir, "work-packages", wp_name + ".gpkg")
+        )
 
-    # new version of the geopackage
-    shutil.copy(os.path.join(wp_alg_output_dir, wp_name + ".gpkg"), os.path.join(wp_dir, gpkg_path))
-
-    if dry_run:
-        print(f"This is a dry run - no changes pushed for work package: {wp_name}")
-        continue
-    print("Uploading new version of the project: " + wp_mergin + " for work package " + wp_name)
-    push_result = push_mergin_project(mc, wp_dir)
-    if push_mergin_project(mc, wp_dir):
-        print("Uploaded a new version: " + mergin.MerginProject(wp_dir).metadata["version"])
+    if ctx.dry_run:
+        print(f"This is a dry run - no changes pushed into the master project: {ctx.master_mergin_project}")
     else:
-        print("No changes (not creating a new version).")
+        print("Uploading new version of the master project: " + ctx.master_mergin_project)
+        if push_mergin_project(ctx.mc, ctx.master_dir):
+            print("Uploaded a new version: " + mergin.MerginProject(ctx.master_dir).metadata["version"])
+        else:
+            print("No changes (not creating a new version).")
+    shutil.rmtree(ctx.tmp_dir)
+    print("Done.")
 
 
-# in the last step, let's update the master project
-# (update the master database file and update base files for work packages)
-shutil.copy(os.path.join(wp_alg_output_dir, "master.gpkg"), os.path.join(master_dir, gpkg_path))
-if not os.path.exists(os.path.join(master_dir, "work-packages")):
-    os.makedirs(os.path.join(master_dir, "work-packages"))
-shutil.copy(os.path.join(wp_alg_output_dir, "master.gpkg"), os.path.join(master_dir, "work-packages", "master.gpkg"))
-shutil.copy(os.path.join(wp_alg_output_dir, "remap.db"), os.path.join(master_dir, "work-packages", "remap.db"))
-for wp in wp_config.wp_names:
-    wp_name, wp_value, wp_mergin = wp.name, wp.value, wp.mergin_project
-    shutil.copy(
-        os.path.join(wp_alg_output_dir, wp_name + ".gpkg"), os.path.join(master_dir, "work-packages", wp_name + ".gpkg")
-    )
+def run_wp_mergin_with_context(ctx: MerginWPContext):
+    initialize(ctx)
+    wp_config, wp_new, gpkg_path, master_project_files = prepare_inputs(ctx)
+    make_work_packages(ctx.wp_alg_dir, wp_config)
+    push_data_to_projects(ctx, wp_config, wp_new, gpkg_path, master_project_files)
 
-if dry_run:
-    print(f"This is a dry run - no changes pushed into the master project: {master_mergin_project}")
-else:
-    print("Uploading new version of the master project: " + master_mergin_project)
-    if push_mergin_project(mc, master_dir):
-        print("Uploaded a new version: " + mergin.MerginProject(master_dir).metadata["version"])
-    else:
-        print("No changes (not creating a new version).")
-shutil.rmtree(tmp_dir)
-print("Done.")
+
+def run_wp_mergin(mergin_project, cache_dir=None, dry_run=False):
+    """ This function can be used to run work packaging from other Python scripts """
+    ctx = MerginWPContext()
+    ctx.master_mergin_project = mergin_project
+    ctx.cache_dir = cache_dir
+    ctx.dry_run = dry_run
+    run_wp_mergin_with_context(ctx)
+
+
+if __name__ == '__main__':
+    run_wp_mergin_with_context(parse_args())


### PR DESCRIPTION
Bug fixes:
1. when pushing to WP mergin project, we correctly report new version if created
   (push call was there twice)
2. avoid ugly warnings from geodiff/sqlite about recovering frames from WAL
   (by closing the sqlite connections when we're done)